### PR TITLE
API update

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,13 @@ pyblish-maya Changelog
 
 This contains all major version changes between pyblish-maya releases.
 
+Version 1.0.13
+--------------
+
+- API: Changed data members current_file -> currentFile and
+    workspace_dir -> workspaceDir. This is a breaking change,
+    make sure to update your plug-ins to use the new names.
+
 Version 1.0.12
 --------------
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 
 Autodesk Maya integration of Pyblish
 
+- [Pyblish][]
 - [Documentation][docs]
-- [Usergroup][usergroup]
 
+[Pyblish]: https://github.com/pyblish/pyblish
 [usergroup]: https://groups.google.com/forum/#!forum/pyblish
 [docs]: https://github.com/pyblish/pyblish-maya/wiki
 [logo]: https://github.com/abstractfactory/pyblish/wiki/images/maya-pyblish.png

--- a/pyblish_maya/lib.py
+++ b/pyblish_maya/lib.py
@@ -242,10 +242,7 @@ def _add_to_filemenu():
                 sys.stderr.write(message)
                 sys.stderr.write("Publishing in headless mode instead.\n")
 
-                util.publish_all()
-
-        if event == "validate":
-            util.validate_all()
+                util.publish()
 
     cmds.menuItem('pyblishOpeningDivider',
                   divider=True,
@@ -257,13 +254,8 @@ def _add_to_filemenu():
                   label='Publish',
                   command=lambda _: filemenu_handler("publish"))
 
-    cmds.menuItem('validateScene',
-                  label='Validate',
-                  insertAfter='pyblishScene',
-                  command=lambda _: filemenu_handler("validate"))
-
     cmds.menuItem('pyblishCloseDivider',
-                  insertAfter='validateScene',
+                  insertAfter='pyblishScene',
                   divider=True)
 
 

--- a/pyblish_maya/plugins/select_current_file.py
+++ b/pyblish_maya/plugins/select_current_file.py
@@ -24,4 +24,4 @@ class SelectCurrentFile(pyblish.api.Selector):
         # Maya returns forward-slashes by default
         normalised = os.path.normpath(current_file)
 
-        context.set_data('current_file', value=normalised)
+        context.set_data('currentFile', value=normalised)

--- a/pyblish_maya/plugins/select_current_file.py
+++ b/pyblish_maya/plugins/select_current_file.py
@@ -25,3 +25,6 @@ class SelectCurrentFile(pyblish.api.Selector):
         normalised = os.path.normpath(current_file)
 
         context.set_data('currentFile', value=normalised)
+
+        # For backwards compatibility
+        context.set_data('current_file', value=normalised)

--- a/pyblish_maya/plugins/select_workspace.py
+++ b/pyblish_maya/plugins/select_workspace.py
@@ -29,3 +29,6 @@ class SelectWorkspace(pyblish.api.Selector):
         normalised = os.path.normpath(workspace)
 
         context.set_data('workspaceDir', value=normalised)
+
+        # For backwards compatibility
+        context.set_data('workspace_dir', value=normalised)

--- a/pyblish_maya/plugins/select_workspace.py
+++ b/pyblish_maya/plugins/select_workspace.py
@@ -28,4 +28,4 @@ class SelectWorkspace(pyblish.api.Selector):
         # Maya returns forward-slashes by default
         normalised = os.path.normpath(workspace)
 
-        context.set_data('workspace_dir', value=normalised)
+        context.set_data('workspaceDir', value=normalised)

--- a/pyblish_maya/version.py
+++ b/pyblish_maya/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 0
-VERSION_PATCH = 12
+VERSION_PATCH = 13
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
mixedCase for data members added by integration.

Old-style attributes are kept for backwards compatibility, but are effectively deprecated and should not be used.