### PR TITLE
Pyblish menuitem appearing in other menus fix

### DIFF
--- a/pyblish_maya/lib.py
+++ b/pyblish_maya/lib.py
@@ -99,10 +99,12 @@ def _add_to_filemenu():
     cmds.menuItem('pyblishScene',
                   insertAfter='pyblishOpeningDivider',
                   label='Publish',
+                  parent='mainFileMenu',
                   command=lambda _: pyblish_maya.show())
 
     cmds.menuItem('pyblishCloseDivider',
                   insertAfter='pyblishScene',
+                  parent='mainFileMenu',
                   divider=True)
 
 


### PR DESCRIPTION
Had "Pyblish" menuitem appear in a custom menu, so explicitly saying which file menu to appear in.