### PR TITLE
Fix special case when empty scene

### DIFF
--- a/pyblish_maya/plugins/collect_current_file.py
+++ b/pyblish_maya/plugins/collect_current_file.py
@@ -19,6 +19,9 @@ class CollectMayaCurrentFile(pyblish.api.ContextPlugin):
 
         # Maya returns forward-slashes by default
         normalised = os.path.normpath(current_file)
+        if normalised == ".":
+            # 'normpath' returns '.' when given an empty string
+            normalised = ""
 
         context.set_data('currentFile', value=normalised)
 

--- a/pyblish_maya/plugins/collect_current_file.py
+++ b/pyblish_maya/plugins/collect_current_file.py
@@ -16,14 +16,11 @@ class CollectMayaCurrentFile(pyblish.api.ContextPlugin):
 
         """Inject the current working file"""
         current_file = cmds.file(sceneName=True, query=True)
+        if current_file:
+            # Maya returns forward-slashes by default
+            current_file = os.path.normpath(current_file)
 
-        # Maya returns forward-slashes by default
-        normalised = os.path.normpath(current_file)
-        if normalised == ".":
-            # 'normpath' returns '.' when given an empty string
-            normalised = ""
-
-        context.set_data('currentFile', value=normalised)
+        context.set_data('currentFile', value=current_file)
 
         # For backwards compatibility
-        context.set_data('current_file', value=normalised)
+        context.set_data('current_file', value=current_file)


### PR DESCRIPTION
# Issue
- Maya's 'cmds.file' returns the empty string "" when the scene hasn't been saved yet (new "untitled" scene).
- Python's 'normpath' function returns the string "." when the provided path is empty ("").

Hence the value set in the context for the current file is "." which is considered valid, though there is no current file.