### PR TITLE
Add the missing two round bracket in lib.py

### DIFF
--- a/pyblish_maya/__init__.py
+++ b/pyblish_maya/__init__.py
@@ -1,4 +1,4 @@
-from version import *
+from .version import *
 
 from .lib import (
     show,

--- a/pyblish_maya/lib.py
+++ b/pyblish_maya/lib.py
@@ -338,7 +338,7 @@ def dock(window):
         raise ValueError("Could not find the main Maya window.")
 
     # Deleting existing dock
-    print "Deleting existing dock..."
+    print("Deleting existing dock...")
     if self._dock:
         self._dock.setParent(None)
         self._dock.deleteLater()
@@ -348,7 +348,7 @@ def dock(window):
             cmds.deleteUI(self._dock_control)
 
     # Creating new dock
-    print "Creating new dock..."
+    print("Creating new dock...")
     dock = Dock(parent=main_window)
 
     dock_control = cmds.dockControl(label=window.windowTitle(), area="right",


### PR DESCRIPTION
A small fix, but the brackets are necessary for Python 3 support.

Forgive me, I modified the `.version` because the `pyblish_qml` used that style and that make me slightly more comfortable lol. 